### PR TITLE
separeate CLI and http/ui => move to kowalski

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,7 +56,7 @@ Our codebase follows SOLID principles to ensure maintainable, scalable software.
 
 **Name**: Kowalski  
 **Release line**: **1.0.0** (workspace; see root `Cargo.toml` and `CHANGELOG.md`).  
-**Purpose**: A Rust-native multi-agent framework: **`kowalski-core`** (agents, LLM, memory, MCP client), **`kowalski-cli`** (REPL + **`serve`** HTTP API), optional **`kowalski-mcp-datafusion`**, Vue **`ui/`**, optional PostgreSQL (**pgvector**, **Apache AGE**).  
+**Purpose**: A Rust-native multi-agent framework: **`kowalski-core`** (agents, LLM, memory, MCP client), **`kowalski-cli`** (REPL + operators), **`kowalski`** (**`serve`** HTTP API), optional **`kowalski-mcp-datafusion`**, Vue **`ui/`**, optional PostgreSQL (**pgvector**, **Apache AGE**).  
 **Core Value Proposition**: Modular, extensible deployment with MCP-first tools and federation-oriented APIs.  
 **Primary Mechanism**: `TemplateAgent` + pluggable tools (built-in + MCP), Ollama/OpenAI-compatible providers.  
 **Target Users**: Developers building operator-run or embedded agent systems on CPU-friendly stacks.  
@@ -124,7 +124,8 @@ Early work used **Qdrant** as a **proof of concept** for semantic (vector) memor
 ```
 kowalski/
 ├── kowalski-core/           # Agents, LLM, memory, MCP, federation (in-crate)
-├── kowalski-cli/            # REPL, `serve` HTTP API, operators
+├── kowalski-cli/            # REPL, operators
+├── kowalski/                # `serve` HTTP API
 ├── kowalski-mcp-datafusion/ # Optional MCP server (DataFusion SQL)
 ├── ui/                      # Vue 3 operator UI (Vite)
 ├── migrations/
@@ -328,7 +329,7 @@ If you can answer these questions, your context management is solid:
 ## 9. Implementation Status
 
 ### Current Status
-**1.0.0** shipped as a consolidated workspace: single **`TemplateAgent`** path in **`kowalski-core`**, **`kowalski-cli`** for REPL + **`serve`**, MCP HTTP client + **`kowalski-mcp-datafusion`** server crate, Vue operator UI, Postgres-backed memory and graph probes when built with **`--features postgres`**.
+**1.0.0** shipped as a consolidated workspace: single **`TemplateAgent`** path in **`kowalski-core`**, **`kowalski-cli`** for REPL/operators, **`kowalski`** for **`serve`**, MCP HTTP client + **`kowalski-mcp-datafusion`** server crate, Vue operator UI, Postgres-backed memory and graph probes when built with **`--features postgres`**.
 
 ### Roadmap
 See [`ROADMAP.md`](ROADMAP.md) (root and per-crate **`ROADMAP.md`** where present).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ All notable changes to this project will be documented in this file, or at least
 ### Added
 
 - **Workspace version 1.0.0** for `kowalski-core`, `kowalski-cli`, `kowalski`, `kowalski-mcp-datafusion`, and the Vue **operator UI** (`ui/`).
-- **HTTP API** (`kowalski-cli serve`): chat, chat stream, tool-aware streaming via **`tools_stream`** on **`POST /api/chat/stream`** (tokens only after tool execution in the same request); graph status and **`POST /api/graph/cypher`** (Apache AGE) when built with **`--features postgres`**.
+- **HTTP API** (`kowalski`): chat, chat stream, tool-aware streaming via **`tools_stream`** on **`POST /api/chat/stream`** (tokens only after tool execution in the same request); graph status and **`POST /api/graph/cypher`** (Apache AGE) when built with **`--features postgres`**.
 - **Vue Chat:** checkbox **Tool-aware stream** (`tools_stream`).
 - **CI:** `pgvector/pgvector:pg16` for default Postgres tests; **`apache/age:release_PG16_1.6.0`** job for **`postgres_age_cypher`** integration test; **`kowalski-cli`** build with **`postgres`** feature.
 - **`kowalski-mcp-datafusion`:** Streamable HTTP MCP server over CSV/Parquet (DataFusion).

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 > "AI agents are like pets – they're cute, but they make a mess."  
 > "The future is modular, and so is Kowalski. Want a feature? Open an issue or submit a PR!"
 
-A sophisticated Rust-based multi-agent framework for interacting with various LLM providers (Ollama, OpenAI-compatible APIs), with MCP tool integration, optional PostgreSQL memory (**pgvector**, **Apache AGE** graph queries), federation hooks, and a small **Vue** operator UI backed by **`kowalski-cli serve`**.
+A sophisticated Rust-based multi-agent framework for interacting with various LLM providers (Ollama, OpenAI-compatible APIs), with MCP tool integration, optional PostgreSQL memory (**pgvector**, **Apache AGE** graph queries), federation hooks, and a small **Vue** operator UI backed by **`kowalski`**.
 
 ---
 
@@ -24,7 +24,8 @@ Kowalski is designed as a foundational framework for building intelligent, distr
 ```
 kowalski/
 ├── kowalski-core/           # Agents, LLM providers, memory, MCP client, federation types
-├── kowalski-cli/            # REPL, `serve` (HTTP API), config/db/mcp tools
+├── kowalski-cli/            # REPL, config/db/mcp tools
+├── kowalski/                # HTTP API server binary (`kowalski`)
 ├── kowalski-mcp-datafusion/ # Standalone MCP server: DataFusion SQL over CSV/Parquet
 ├── ui/                      # Vue 3 + Vite operator UI (Chat, MCP, federation, graph status)
 ├── migrations/
@@ -45,7 +46,10 @@ kowalski/
 - [See details](./kowalski-core/README.md)
 
 ### **kowalski-cli**
-- The main command-line interface: `chat`, `run`, `serve` (HTTP JSON API on `127.0.0.1:3456` by default), `config`, `db migrate`, `doctor`, `mcp ping` / `mcp tools`.
+- The command-line interface: `chat`, `run`, `config`, `db migrate`, `doctor`, `mcp ping` / `mcp tools`.
+
+### **kowalski**
+- The HTTP API server binary: `serve` (HTTP JSON API on `127.0.0.1:3456` by default).
 - Build with **`--features postgres`** for SQL memory + pgvector bindings and **`POST /api/graph/cypher`** (Apache AGE) on `serve`.
 
 ### **kowalski-mcp-datafusion**
@@ -74,7 +78,7 @@ cd kowalski
 cargo build --release
 ```
 
-The main binary is **`kowalski-cli`** (`target/release/kowalski-cli`). Adjust `config.toml` in the repo root (or pass `-c` / `--config` where supported) for models, MCP servers, and memory.
+Main binaries are **`kowalski-cli`** (`target/release/kowalski-cli`) and **`kowalski`** (`target/release/kowalski`). Adjust `config.toml` in the repo root (or pass `-c` / `--config` where supported) for models, MCP servers, and memory.
 
 ### 3. Ollama (typical local setup)
 
@@ -106,7 +110,7 @@ Tools and MCP are driven by **`TemplateAgent`** + config, not separate `kowalski
 ./target/release/kowalski-cli run -c config.toml
 
 # HTTP API for the Vue UI (default bind 127.0.0.1:3456)
-./target/release/kowalski-cli serve -c config.toml
+./target/release/kowalski -c config.toml
 
 # MCP servers from config: initialize + tools/list
 ./target/release/kowalski-cli mcp ping -c config.toml
@@ -122,17 +126,17 @@ Tools and MCP are driven by **`TemplateAgent`** + config, not separate `kowalski
 ./target/release/kowalski-cli chat my-agent-name
 ```
 
-Build with **`--features postgres`** on `kowalski-cli` for Postgres memory, graph routes, and federation helpers (`cargo build -p kowalski-cli --features postgres`).
+Build with **`--features postgres`** on `kowalski` for Postgres memory and graph routes (`cargo build -p kowalski --features postgres`).
 
 ### Vue UI (`ui/`)
 
-The web UI lives in **[`ui/`](./ui/)** at the repository root (Vue 3 + Vite). It talks to the backend via **`kowalski-cli serve`**: the dev server proxies **`/api`** to **`http://127.0.0.1:3456`** (see `ui/vite.config.ts`).
+The web UI lives in **[`ui/`](./ui/)** at the repository root (Vue 3 + Vite). It talks to the backend via **`kowalski`**: the dev server proxies **`/api`** to **`http://127.0.0.1:3456`** (see `ui/vite.config.ts`).
 
 **Two terminals:**
 
 ```bash
 # Terminal 1 — HTTP API (must be up first)
-./target/release/kowalski-cli serve -c config.toml
+./target/release/kowalski -c config.toml
 
 # Terminal 2 — Vite (default http://localhost:5173)
 cd ui && npm install && npm run dev
@@ -182,7 +186,7 @@ Legacy prompt configurations are currently stored in `migrations/legacy_prompts/
 - [CHANGELOG.md](./CHANGELOG.md)
 - [ROADMAP.md](./ROADMAP.md)
 - **[TODO.md](./TODO.md)** — manual & end-to-end verification (operator checklist)
-- **[`ui/README.md`](./ui/README.md)** — Vue operator UI (dev, build, proxy to `serve`)
+- **[`ui/README.md`](./ui/README.md)** — Vue operator UI (dev, build, proxy to `kowalski`)
 - [Each module's README](./kowalski-core/README.md), etc.
 
 ---

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ kowalski/
 - [See details](./kowalski-core/README.md)
 
 ### **kowalski-cli**
-- The main command-line interface: `chat`, `run`, `serve` (HTTP JSON API on `127.0.0.1:3000` by default), `config`, `db migrate`, `doctor`, `mcp ping` / `mcp tools`.
+- The main command-line interface: `chat`, `run`, `serve` (HTTP JSON API on `127.0.0.1:3456` by default), `config`, `db migrate`, `doctor`, `mcp ping` / `mcp tools`.
 - Build with **`--features postgres`** for SQL memory + pgvector bindings and **`POST /api/graph/cypher`** (Apache AGE) on `serve`.
 
 ### **kowalski-mcp-datafusion**
@@ -105,7 +105,7 @@ Tools and MCP are driven by **`TemplateAgent`** + config, not separate `kowalski
 # Orchestrator REPL (TemplateAgent + tools; uses config.toml by default)
 ./target/release/kowalski-cli run -c config.toml
 
-# HTTP API for the Vue UI (default bind 127.0.0.1:3000)
+# HTTP API for the Vue UI (default bind 127.0.0.1:3456)
 ./target/release/kowalski-cli serve -c config.toml
 
 # MCP servers from config: initialize + tools/list
@@ -126,7 +126,7 @@ Build with **`--features postgres`** on `kowalski-cli` for Postgres memory, grap
 
 ### Vue UI (`ui/`)
 
-The web UI lives in **[`ui/`](./ui/)** at the repository root (Vue 3 + Vite). It talks to the backend via **`kowalski-cli serve`**: the dev server proxies **`/api`** to **`http://127.0.0.1:3000`** (see `ui/vite.config.ts`).
+The web UI lives in **[`ui/`](./ui/)** at the repository root (Vue 3 + Vite). It talks to the backend via **`kowalski-cli serve`**: the dev server proxies **`/api`** to **`http://127.0.0.1:3456`** (see `ui/vite.config.ts`).
 
 **Two terminals:**
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # Kowalski
 
+> [!IMPORTANT]
+> ## WIP 1.0.x - Refactoring Phase
+> Kowalski is currently in an active refactoring and hardening phase.
+> The project is moving from an original proof-of-concept/proof-of-knowledge stage toward a near-production release line.
+> During this transition, some modules, commands, and docs may still evolve quickly.
+> We are focused on stability, clearer module boundaries, production-ready operator workflows, and robust multi-agent federation.
+
 **Version 1.0.0** · Rust workspace (`kowalski-core`, `kowalski-cli`, `kowalski-mcp-datafusion`, Vue `ui/`)
 
 > "AI agents are like pets – they're cute, but they make a mess."  

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -11,7 +11,8 @@
 
 Workspace layout:
 - **kowalski-core**: `TemplateAgent`, LLM providers, memory, MCP client/hub, federation types; optional **Postgres** + **pgvector** + **Apache AGE** helpers.
-- **kowalski-cli**: REPL, **`serve`** (HTTP API for the Vue UI), operator commands.
+- **kowalski-cli**: REPL and operator commands.
+- **kowalski**: **`serve`** HTTP API for the Vue UI.
 - **kowalski-mcp-datafusion**: standalone **MCP** Streamable HTTP server (DataFusion over CSV/Parquet).
 - **ui**: Vue 3 + Vite operator UI (Chat / MCP / federation / graph status).
 - **Legacy prompts**: `migrations/legacy_prompts/` (staged).
@@ -53,7 +54,7 @@ Workspace layout:
 - [x] Role assignment (coordinator, worker, observer)
 - [x] Task delegation and assignment
 - [x] Message passing and broadcasting
-- [x] In-process + SSE broker; optional Postgres `LISTEN`/`NOTIFY` bridge (see `kowalski-cli serve` with `--features postgres`)
+- [x] In-process + SSE broker; optional Postgres `LISTEN`/`NOTIFY` bridge (see `kowalski` with `--features postgres`)
 - [ ] Protocol selection (A2A, ACP, MCP, or custom) (open)
 - [ ] Secure agent authentication (planned)
 - [x] Persistent registry records (Postgres-backed when configured)
@@ -69,7 +70,7 @@ Workspace layout:
 
 ## User Interface & Integration
 - [x] CLI interface with rich formatting
-- [x] Vue operator UI (`ui/`) + **`kowalski-cli serve`** HTTP API
+- [x] Vue operator UI (`ui/`) + **`kowalski`** HTTP API
 - [x] REST-style JSON API under `/api/*` (chat, stream, MCP, federation, graph)
 - [x] WebSocket `/api/federation/ws` (and SSE stream) where enabled
 - [ ] Export conversations (PDF, HTML, Markdown) (planned)

--- a/TODO.md
+++ b/TODO.md
@@ -80,7 +80,7 @@
 | WP3-M2 | **Episodic tier on Postgres** | With `memory.database_url` set to Postgres: exercise chat, then query `episodic_kv` (or relevant tables) for expected rows; optional **restart CLI** and confirm recall if persistence path is enabled. |
 | WP3-M3 | **pgvector similarity** | With semantic memory on Postgres + embeddings: run a retrieval turn and confirm sensible rows (no strict CI assertion yet). |
 | WP3-M4 | **Apache AGE / Cypher** | With **`kowalski-cli --features postgres`**, AGE installed, graph created: call **`POST /api/graph/cypher`** or use `kowalski_core::postgres_age_cypher` — Cypher must **`RETURN … AS result`**. CI uses `apache/age` image for one integration test; production DBs need manual smoke. |
-| WP3-M5 | **Restart recalls memory** | Tier-2/3 persistence configured: send messages, restart `serve`, new session or same config — confirm expected memory behavior (manual; semantics depend on config). |
+| WP3-M5 | **Restart recalls memory** | Tier-2/3 persistence configured: send messages, restart `kowalski`, new session or same config — confirm expected memory behavior (manual; semantics depend on config). |
 
 ---
 
@@ -88,8 +88,8 @@
 
 | ID | What to verify | How (summary) |
 |----|----------------|----------------|
-| WP4-M1 | **Ollama end-to-end** | `ollama serve`, model pulled. `kowalski-cli serve` + UI or `POST /api/chat` — expect a normal reply. |
-| WP4-M2 | **OpenAI-compatible end-to-end** | `[llm] provider = "openai"`, `openai_api_base` (LM Studio, Groq, vLLM, …), optional key; `[ollama].model` as model id. Verify via `serve` + `/api/chat` or CLI `chat`. |
+| WP4-M1 | **Ollama end-to-end** | `ollama serve`, model pulled. `kowalski` + UI or `POST /api/chat` — expect a normal reply. |
+| WP4-M2 | **OpenAI-compatible end-to-end** | `[llm] provider = "openai"`, `openai_api_base` (LM Studio, Groq, vLLM, …), optional key; `[ollama].model` as model id. Verify via `kowalski` + `/api/chat` or CLI `chat`. |
 | WP4-M3 | **JSON parser under load** | Feed **mangled** tool-shaped responses (fences, partial JSON) through **`chat_with_tools`** with MCP or built-in tools; confirm repair / self-correction path without panic. |
 | WP4-M4 | **Self-correction loop** | Provoke invalid tool JSON once; confirm hint / next turn recovers (see `utils/json` + agent loop). |
 

--- a/kowalski-cli/AGENTS.md
+++ b/kowalski-cli/AGENTS.md
@@ -56,7 +56,7 @@ Our codebase follows SOLID principles to ensure maintainable, scalable software.
 
 **Name**: kowalski-cli  
 **Release**: **1.0.0** (see crate `Cargo.toml`).  
-**Purpose**: Command-line interface and **HTTP server** (`serve`) for the Vue operator UI: `/api/chat`, `/api/chat/stream` (with **`tools_stream`**), MCP, federation, graph status / Cypher (Postgres + AGE).  
+**Purpose**: Command-line interface (REPL + operators). The HTTP server (`kowalski`) for the Vue operator UI exposes `/api/chat`, `/api/chat/stream` (with **`tools_stream`**), MCP, federation, graph status / Cypher (Postgres + AGE).  
 **Core Value Proposition**: Modular, extensible, and distributed architecture supporting standalone and federated deployments with privacy-preserving capabilities.  
 **Primary Mechanism**: Multi-agent orchestration and pluggable tools interfacing with local (Ollama) and remote LLMs.  
 **Target Users**: Kowalski framework agents and developers integrating kowalski-cli.  
@@ -336,7 +336,7 @@ If you can answer these questions, your context management is solid:
 ## 9. Implementation Status
 
 ### Current Status
-**1.0.0**: `kowalski`, `kowalski chat`, `kowalski run`, `kowalski serve`, `config`, `db`, `doctor`, `mcp ping` / `mcp tools`. Build with **`--features postgres`** for SQL memory alignment with `serve` graph routes.
+**1.0.0**: `kowalski-cli` provides CLI operators (`run`, `config`, `db`, `doctor`, `mcp`, `federation`). `kowalski` provides `serve`. Build with **`--features postgres`** for SQL memory alignment with `serve` graph routes.
 
 ### Roadmap
 See [`ROADMAP.md`](ROADMAP.md) here and root [`../ROADMAP.md`](../ROADMAP.md).
@@ -345,7 +345,7 @@ See [`ROADMAP.md`](ROADMAP.md) here and root [`../ROADMAP.md`](../ROADMAP.md).
 - Legacy “multi-agent” REPL sections in this file may predate the unified `TemplateAgent`; verify against `src/main.rs` and `ops.rs`.
 
 ### Known Issues
-- `serve` requires a valid TOML config and a running LLM endpoint for chat tabs.
+- `kowalski` requires a valid TOML config and a running LLM endpoint for chat tabs.
 
 ---
 

--- a/kowalski-cli/PACKAGING.md
+++ b/kowalski-cli/PACKAGING.md
@@ -13,8 +13,8 @@ Copy `target/release/kowalski-cli` (or workspace package name if renamed) plus a
 ## systemd (sketch)
 
 - `User=` and `WorkingDirectory=` pointing at config.
-- `ExecStart=/usr/local/bin/kowalski-cli serve --bind 127.0.0.1:3000 -c /etc/kowalski/config.toml`
-- For TLS: add `--tls-cert` and `--tls-key` paths; or terminate TLS at **nginx** / **Caddy** and proxy to `localhost:3000`.
+- `ExecStart=/usr/local/bin/kowalski-cli serve --bind 127.0.0.1:3456 -c /etc/kowalski/config.toml`
+- For TLS: add `--tls-cert` and `--tls-key` paths; or terminate TLS at **nginx** / **Caddy** and proxy to `localhost:3456`.
 
 ## Container
 

--- a/kowalski-cli/PACKAGING.md
+++ b/kowalski-cli/PACKAGING.md
@@ -1,6 +1,6 @@
 # Packaging and deployment (operators)
 
-The default binary is intentionally self-contained. Heavier TLS (rustls via `axum-server`) is linked for optional **`serve --tls-cert` / `--tls-key`** HTTPS.
+The default binary is intentionally self-contained. Heavier TLS (rustls via `axum-server`) is linked for optional **`--tls-cert` / `--tls-key`** HTTPS on the `kowalski` server binary.
 
 ## Static binary
 
@@ -13,14 +13,14 @@ Copy `target/release/kowalski-cli` (or workspace package name if renamed) plus a
 ## systemd (sketch)
 
 - `User=` and `WorkingDirectory=` pointing at config.
-- `ExecStart=/usr/local/bin/kowalski-cli serve --bind 127.0.0.1:3456 -c /etc/kowalski/config.toml`
+- `ExecStart=/usr/local/bin/kowalski --bind 127.0.0.1:3456 -c /etc/kowalski/config.toml`
 - For TLS: add `--tls-cert` and `--tls-key` paths; or terminate TLS at **nginx** / **Caddy** and proxy to `localhost:3456`.
 
 ## Container
 
 - Multi-stage: `cargo build --release` then `FROM debian:bookworm-slim` (or `distroless`) with the binary and `config.toml`.
-- Expose the `serve` port; set `memory.database_url` via env or mounted secret if using Postgres.
+- Expose the `kowalski` port; set `memory.database_url` via env or mounted secret if using Postgres.
 
 ## UI
 
-Build the Vue app in `../ui` and point **`VITE_API_BASE`** at the public URL of `serve` (see `ui/DEPLOY.md`).
+Build the Vue app in `../ui` and point **`VITE_API_BASE`** at the public URL of `kowalski` (see `ui/DEPLOY.md`).

--- a/kowalski-cli/README.md
+++ b/kowalski-cli/README.md
@@ -2,7 +2,7 @@
 
 **Crate version 1.0.0** · See [`ROADMAP.md`](./ROADMAP.md) and root [`README.md`](../README.md).
 
-A command-line interface for the Kowalski AI agent framework: REPL, **`serve`** (HTTP API for the Vue UI), and operator commands (`config`, `db`, `doctor`, `mcp`).
+A command-line interface for the Kowalski AI agent framework: REPL and operator commands (`config`, `db`, `doctor`, `mcp`). The HTTP API for the Vue UI is provided by **`kowalski`**.
 
 ## Overview
 

--- a/kowalski-cli/src/lib.rs
+++ b/kowalski-cli/src/lib.rs
@@ -2,6 +2,5 @@ pub mod config;
 pub mod error;
 pub mod federation_ops;
 pub mod run_ops;
-pub mod http_api;
 pub mod interactive;
 pub mod ops;

--- a/kowalski-cli/src/main.rs
+++ b/kowalski-cli/src/main.rs
@@ -108,8 +108,8 @@ enum Commands {
     },
     /// Expose a minimal JSON HTTP API for the Vue UI (`GET /api/health`, etc.)
     Serve {
-        /// Listen address (default 127.0.0.1:3000 — matches `ui/vite.config.ts` proxy)
-        #[clap(long, default_value = "127.0.0.1:3000")]
+        /// Listen address (default 127.0.0.1:3456 — matches `ui/vite.config.ts` proxy)
+        #[clap(long, default_value = "127.0.0.1:3456")]
         bind: String,
         /// Config TOML for MCP listing/ping (default ./config.toml)
         #[clap(short, long)]

--- a/kowalski-cli/src/main.rs
+++ b/kowalski-cli/src/main.rs
@@ -17,7 +17,7 @@ use kowalski_core::memory::consolidation::{Consolidator, MemoryWeaver};
     author,
     version,
     about = "Kowalski CLI — agents, memory, and MCP operators.",
-    long_about = "Operators: `run`, `config check`, `db migrate`, `doctor`, `mcp ping`, `mcp tools`, `federation ping-notify` (with `--features postgres`), `serve` (see --help on each)."
+    long_about = "Operators: `run`, `config check`, `db migrate`, `doctor`, `mcp ping`, `mcp tools`, `federation ping-notify` (with `--features postgres`) (see --help on each)."
 )]
 struct Cli {
     #[clap(subcommand)]
@@ -105,24 +105,6 @@ enum Commands {
     Federation {
         #[clap(subcommand)]
         command: FederationCommands,
-    },
-    /// Expose a minimal JSON HTTP API for the Vue UI (`GET /api/health`, etc.)
-    Serve {
-        /// Listen address (default 127.0.0.1:3456 — matches `ui/vite.config.ts` proxy)
-        #[clap(long, default_value = "127.0.0.1:3456")]
-        bind: String,
-        /// Config TOML for MCP listing/ping (default ./config.toml)
-        #[clap(short, long)]
-        config: Option<String>,
-        /// Ollama base URL for `/api/doctor` (default http://127.0.0.1:11434)
-        #[clap(long)]
-        ollama_url: Option<String>,
-        /// TLS certificate (PEM). Must be set together with `--tls-key`.
-        #[clap(long, value_name = "PEM")]
-        tls_cert: Option<std::path::PathBuf>,
-        /// TLS private key (PEM). Must be set together with `--tls-cert`.
-        #[clap(long, value_name = "PEM")]
-        tls_key: Option<std::path::PathBuf>,
     },
 }
 
@@ -510,28 +492,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 kowalski_cli::federation_ops::run_ping_notify(config.as_deref()).await?;
             }
         },
-        Some(Commands::Serve {
-            bind,
-            config,
-            ollama_url,
-            tls_cert,
-            tls_key,
-        }) => {
-            let addr: std::net::SocketAddr = bind.parse().map_err(|e| {
-                format!("Invalid --bind {:?}: {}", bind, e)
-            })?;
-            let tls = match (tls_cert, tls_key) {
-                (Some(c), Some(k)) => Some((c, k)),
-                (None, None) => None,
-                _ => {
-                    return Err(
-                        "--tls-cert and --tls-key must be set together (or both omitted)"
-                            .into(),
-                    );
-                }
-            };
-            kowalski_cli::http_api::serve(addr, config, ollama_url, tls).await?;
-        },
         Some(Commands::Consolidate { delete }) => {
             let config = Config::default();
             let ollama_model = &config.ollama.model;
@@ -703,7 +663,7 @@ async fn repl(manager: AgentManager) -> Result<(), Box<dyn std::error::Error>> {
                 println!("  kowalski-cli db migrate [--url] [-c config.toml]");
                 println!("  kowalski-cli doctor [--ollama-url URL]");
                 println!("  kowalski-cli federation ping-notify [-c config.toml]  — pg_notify smoke (needs --features postgres)");
-                println!("  kowalski-cli serve …  — /api/federation/registry, /api/federation/stream (SSE), /api/federation/delegate; with --features postgres + memory.database_url, LISTEN kowalski_federation → broker");
+                println!("  kowalski serve …      — /api/federation/registry, /api/federation/stream (SSE), /api/federation/delegate; with --features postgres + memory.database_url, LISTEN kowalski_federation → broker");
             }
             "create" => {
                 let agent_type = parts.next();

--- a/kowalski-cli/src/main.rs
+++ b/kowalski-cli/src/main.rs
@@ -663,7 +663,7 @@ async fn repl(manager: AgentManager) -> Result<(), Box<dyn std::error::Error>> {
                 println!("  kowalski-cli db migrate [--url] [-c config.toml]");
                 println!("  kowalski-cli doctor [--ollama-url URL]");
                 println!("  kowalski-cli federation ping-notify [-c config.toml]  — pg_notify smoke (needs --features postgres)");
-                println!("  kowalski serve …      — /api/federation/registry, /api/federation/stream (SSE), /api/federation/delegate; with --features postgres + memory.database_url, LISTEN kowalski_federation → broker");
+                println!("  kowalski  — /api/federation/registry, /api/federation/stream (SSE), /api/federation/delegate; with --features postgres + memory.database_url, LISTEN kowalski_federation → broker");
             }
             "create" => {
                 let agent_type = parts.next();

--- a/kowalski-cli/src/ops.rs
+++ b/kowalski-cli/src/ops.rs
@@ -12,7 +12,7 @@ pub fn mcp_config_path(config_path: Option<&str>) -> PathBuf {
         .unwrap_or_else(|| PathBuf::from("config.toml"))
 }
 
-/// Load full [`Config`] for `kowalski-cli serve` (HTTP chat + MCP). Missing file → [`Config::default`].
+/// Load full [`Config`] for `kowalski` server mode (HTTP chat + MCP). Missing file → [`Config::default`].
 pub fn load_kowalski_config_for_serve(path: &Path) -> Result<Config, Box<dyn std::error::Error>> {
     if !path.exists() {
         log::warn!(

--- a/kowalski-cli/src/run_ops.rs
+++ b/kowalski-cli/src/run_ops.rs
@@ -21,7 +21,7 @@ pub async fn run_orchestrator(config_path: Option<&str>) -> Result<(), Box<dyn s
     );
     println!("Commands: /bye exit · /new new session · lines ending with \\ continue");
     println!("Lines are prefixed with [agent] (LLM) and [tool] (tool round) for readability.");
-    println!("Federation: use `serve` + Vue or `curl` to /api/federation/* (HTTP + optional Postgres NOTIFY).");
+    println!("Federation: use `kowalski` + Vue or `curl` to /api/federation/* (HTTP + optional Postgres NOTIFY).");
 
     let mut rl = DefaultEditor::new()?;
     let mut pending = String::new();

--- a/kowalski/Cargo.toml
+++ b/kowalski/Cargo.toml
@@ -24,11 +24,11 @@ keywords = [
 [dependencies]
 # Core components are non-optional
 kowalski-core = { path = "../kowalski-core", version = "1.0.0" }
-
-# Optional CLI
-kowalski-cli = { path = "../kowalski-cli", version = "1.0.0", optional = true }
+kowalski-cli = { path = "../kowalski-cli", version = "1.0.0" }
 
 tokio = { workspace = true }
+clap = { version = "4.5", features = ["derive"] }
+env_logger = { workspace = true }
 
 [lib]
 name = "kowalski"
@@ -38,7 +38,7 @@ path = "src/lib.rs"
 default = []
 
 # Other features
-cli = ["dep:kowalski-cli"]
+cli = []
 postgres = ["kowalski-core/postgres"]
 
 # All features (CLI + PostgreSQL client stack)

--- a/kowalski/Cargo.toml
+++ b/kowalski/Cargo.toml
@@ -24,11 +24,20 @@ keywords = [
 [dependencies]
 # Core components are non-optional
 kowalski-core = { path = "../kowalski-core", version = "1.0.0" }
-kowalski-cli = { path = "../kowalski-cli", version = "1.0.0" }
 
 tokio = { workspace = true }
 clap = { version = "4.5", features = ["derive"] }
 env_logger = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+log = { workspace = true }
+futures = { workspace = true }
+axum = { workspace = true, features = ["ws"] }
+tokio-stream = { version = "0.1", features = ["sync"] }
+tower-http = { workspace = true, features = ["cors", "trace"] }
+reqwest = { workspace = true }
+axum-server = { version = "0.8.0", features = ["tls-rustls"] }
+toml = { workspace = true }
 
 [lib]
 name = "kowalski"

--- a/kowalski/src/http_api.rs
+++ b/kowalski/src/http_api.rs
@@ -2,32 +2,30 @@
 //! `/api/chat` and `/api/chat/stream` use one in-process `TemplateAgent` + configured LLM (`[llm]` +
 //! `[ollama].model` — Ollama or OpenAI-compatible API).
 
-use axum::extract::State;
-use axum::http::StatusCode;
-use axum::response::sse::{Event, Sse};
 use axum::extract::Query;
+use axum::extract::State;
 use axum::extract::ws::{WebSocket, WebSocketUpgrade};
+use axum::http::StatusCode;
 use axum::response::IntoResponse;
+use axum::response::sse::{Event, Sse};
 use axum::routing::{get, post};
 use axum::{Json, Router};
 use futures::Stream;
 use futures::StreamExt;
-use std::convert::Infallible;
-use tokio_stream::wrappers::ReceiverStream;
 use kowalski_core::agent::Agent;
 use kowalski_core::config::Config;
-use kowalski_core::federation::{
-    AgentRecord, AgentRegistry, FederationOrchestrator, MpscBroker,
-};
+use kowalski_core::federation::{AgentRecord, AgentRegistry, FederationOrchestrator, MpscBroker};
 #[cfg(feature = "postgres")]
 use kowalski_core::federation::MessageBroker;
 use kowalski_core::template::agent::TemplateAgent;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
+use std::convert::Infallible;
 use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::sync::Mutex;
+use tokio_stream::wrappers::ReceiverStream;
 use tower_http::cors::CorsLayer;
 use tower_http::trace::{DefaultMakeSpan, DefaultOnResponse, TraceLayer};
 
@@ -67,8 +65,8 @@ pub async fn serve(
     ollama_url: Option<String>,
     tls: Option<(PathBuf, PathBuf)>,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let config_path = crate::ops::mcp_config_path(config.as_deref());
-    let full_config = crate::ops::load_kowalski_config_for_serve(&config_path)?;
+    let config_path = crate::http_ops::mcp_config_path(config.as_deref());
+    let full_config = crate::http_ops::load_kowalski_config_for_serve(&config_path)?;
     kowalski_core::db::run_memory_migrations_if_configured(&full_config).await?;
 
     let mut agent = TemplateAgent::new(full_config.clone()).await?;
@@ -80,9 +78,7 @@ pub async fn serve(
     #[cfg(feature = "postgres")]
     if let Some(ref url) = full_config.memory.database_url {
         if kowalski_core::config::memory_uses_postgres(&full_config.memory) {
-            if let Err(e) =
-                kowalski_core::load_registry_into(&federation_registry, url).await
-            {
+            if let Err(e) = kowalski_core::load_registry_into(&federation_registry, url).await {
                 log::warn!("federation registry DB load: {}", e);
             }
         }
@@ -106,10 +102,8 @@ pub async fn serve(
             }
         }
     }
-    let mut federation = FederationOrchestrator::new(
-        federation_registry.clone(),
-        federation_broker.clone(),
-    );
+    let mut federation =
+        FederationOrchestrator::new(federation_registry.clone(), federation_broker.clone());
     federation.orchestrator_id = "kowalski-serve".into();
     federation.default_topic = "federation".into();
     let federation = Arc::new(federation);
@@ -179,7 +173,10 @@ pub async fn serve(
         .route("/api/federation/registry", get(get_federation_registry))
         .route("/api/federation/register", post(post_federation_register))
         .route("/api/federation/deregister", post(post_federation_deregister))
-        .route("/api/federation/cleanup-stale", post(post_federation_cleanup_stale))
+        .route(
+            "/api/federation/cleanup-stale",
+            post(post_federation_cleanup_stale),
+        )
         .route("/api/federation/heartbeat", post(post_federation_heartbeat))
         .route("/api/federation/delegate", post(post_federation_delegate))
         .route("/api/graph/status", get(get_graph_status));
@@ -221,7 +218,7 @@ fn federation_postgres_notify_bridge(state: &ApiState) -> bool {
 async fn get_health(State(state): State<ApiState>) -> Json<serde_json::Value> {
     Json(json!({
         "status": "ok",
-        "service": "kowalski-cli",
+        "service": "kowalski",
         "version": env!("CARGO_PKG_VERSION"),
         "model": state.model,
         "federation": {
@@ -258,24 +255,22 @@ async fn get_sessions(State(state): State<ApiState>) -> Json<serde_json::Value> 
     }))
 }
 
-async fn get_doctor(State(state): State<ApiState>) -> Json<crate::ops::DoctorJson> {
-    Json(
-        crate::ops::doctor_json(state.ollama_url.clone(), Some(&state.full_config)).await,
-    )
+async fn get_doctor(State(state): State<ApiState>) -> Json<crate::http_ops::DoctorJson> {
+    Json(crate::http_ops::doctor_json(state.ollama_url.clone(), Some(&state.full_config)).await)
 }
 
 async fn get_mcp_servers(
     State(state): State<ApiState>,
-) -> Result<Json<Vec<crate::ops::McpServerPublic>>, (StatusCode, String)> {
-    crate::ops::list_mcp_servers_public(&state.config_path)
+) -> Result<Json<Vec<crate::http_ops::McpServerPublic>>, (StatusCode, String)> {
+    crate::http_ops::list_mcp_servers_public(&state.config_path)
         .map(Json)
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))
 }
 
 async fn post_mcp_ping(
     State(state): State<ApiState>,
-) -> Result<Json<Vec<crate::ops::McpPingResult>>, (StatusCode, String)> {
-    crate::ops::mcp_ping_results(&state.config_path)
+) -> Result<Json<Vec<crate::http_ops::McpPingResult>>, (StatusCode, String)> {
+    crate::http_ops::mcp_ping_results(&state.config_path)
         .await
         .map(Json)
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))
@@ -289,22 +284,22 @@ async fn get_memory_status(
             &state.full_config.ollama.host,
             state.full_config.ollama.port,
         ));
-    let episodic = kowalski_core::memory::episodic::EpisodicBuffer::open(
-        &state.full_config.memory,
-        llm_provider,
-    )
-    .await
-    .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    let episodic =
+        kowalski_core::memory::episodic::EpisodicBuffer::open(&state.full_config.memory, llm_provider)
+            .await
+            .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
     let memories = episodic
         .retrieve_all()
         .await
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
     let missing_embeddings = memories.iter().filter(|m| m.embedding.is_none()).count();
 
-    let ollama_url = state
-        .ollama_url
-        .clone()
-        .unwrap_or_else(|| format!("http://{}:{}", state.full_config.ollama.host, state.full_config.ollama.port));
+    let ollama_url = state.ollama_url.clone().unwrap_or_else(|| {
+        format!(
+            "http://{}:{}",
+            state.full_config.ollama.host, state.full_config.ollama.port
+        )
+    });
     let embed_model = "nomic-embed-text".to_string();
     let probe = reqwest::Client::new()
         .post(format!("{}/api/embeddings", ollama_url.trim_end_matches('/')))
@@ -522,10 +517,7 @@ async fn post_chat_stream(
         }
         {
             let mut guard = api.chat.lock().await;
-            guard
-                .agent
-                .add_message(&conv_id, "assistant", &full)
-                .await;
+            guard.agent.add_message(&conv_id, "assistant", &full).await;
         }
         let summary = json!({ "type": "assistant", "content": full });
         let _ = tx
@@ -727,18 +719,15 @@ async fn post_federation_delegate(
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
 
     #[cfg(feature = "postgres")]
-    if let (Some(ref url), Some(o)) = (
-        state.full_config.memory.database_url.as_ref(),
-        outcome.as_ref(),
-    ) {
+    if let (Some(ref url), Some(o)) = (state.full_config.memory.database_url.as_ref(), outcome.as_ref())
+    {
         if kowalski_core::config::memory_uses_postgres(&state.full_config.memory) {
             let task_label = format!(
                 "{}: {}",
                 body.task_id,
                 body.instruction.chars().take(240).collect::<String>()
             );
-            if let Err(e) = kowalski_core::set_agent_current_task(url, &o.agent_id, &task_label).await
-            {
+            if let Err(e) = kowalski_core::set_agent_current_task(url, &o.agent_id, &task_label).await {
                 log::warn!("federation current_task: {}", e);
             }
         }
@@ -832,18 +821,19 @@ async fn post_federation_deregister(
 #[derive(Deserialize)]
 struct FederationCleanupBody {
     /// Heartbeats older than this many seconds are treated as stale (`active = false`).
-    stale_after_secs: u64,
+    #[serde(rename = "stale_after_secs")]
+    _stale_after_secs: u64,
 }
 
 async fn post_federation_cleanup_stale(
-    State(state): State<ApiState>,
-    Json(body): Json<FederationCleanupBody>,
+    State(_state): State<ApiState>,
+    Json(_body): Json<FederationCleanupBody>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
     #[cfg(feature = "postgres")]
     {
-        if let Some(ref url) = state.full_config.memory.database_url {
-            if kowalski_core::config::memory_uses_postgres(&state.full_config.memory) {
-                let n = kowalski_core::mark_stale_agents_inactive(url, body.stale_after_secs)
+        if let Some(ref url) = _state.full_config.memory.database_url {
+            if kowalski_core::config::memory_uses_postgres(&_state.full_config.memory) {
+                let n = kowalski_core::mark_stale_agents_inactive(url, _body._stale_after_secs)
                     .await
                     .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
                 return Ok(Json(json!({ "ok": true, "rows_updated": n })));

--- a/kowalski/src/http_ops.rs
+++ b/kowalski/src/http_ops.rs
@@ -1,0 +1,226 @@
+use kowalski_core::config::{Config, McpConfig, McpTransport};
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Deserialize)]
+struct McpSection {
+    #[serde(default)]
+    mcp: McpConfig,
+}
+
+fn load_mcp_config_from_file(path: &Path) -> Result<McpConfig, Box<dyn std::error::Error>> {
+    let content = fs::read_to_string(path)?;
+    let section: McpSection = toml::from_str(&content)?;
+    Ok(section.mcp)
+}
+
+pub fn mcp_config_path(config_path: Option<&str>) -> PathBuf {
+    config_path
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("config.toml"))
+}
+
+pub fn load_kowalski_config_for_serve(path: &Path) -> Result<Config, Box<dyn std::error::Error>> {
+    if !path.exists() {
+        log::warn!(
+            "No config at {} — using defaults (Ollama localhost; add config.toml for MCP/tools)",
+            path.display()
+        );
+        return Ok(Config::default());
+    }
+    let raw = fs::read_to_string(path)?;
+    Ok(toml::from_str(&raw)?)
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct McpServerPublic {
+    pub name: String,
+    pub url: String,
+    pub transport: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct McpPingResult {
+    pub name: String,
+    pub url: String,
+    pub transport: String,
+    pub ok: bool,
+    pub tool_count: Option<usize>,
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct DoctorJson {
+    pub server_version: String,
+    pub ollama: OllamaProbeJson,
+    pub llm: LlmDoctorJson,
+    pub operator: DoctorOperatorJson,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct DoctorOperatorJson {
+    pub mcp_servers_configured: usize,
+    pub postgres_memory_configured: bool,
+    pub config_divergence: Vec<String>,
+    pub mcp_streamable_session_note: &'static str,
+}
+
+pub fn config_divergence_lines(c: &Config) -> Vec<String> {
+    let d = Config::default();
+    let mut v = Vec::new();
+    if c.ollama.model != d.ollama.model {
+        v.push("ollama.model".into());
+    }
+    if c.ollama.host != d.ollama.host || c.ollama.port != d.ollama.port {
+        v.push("ollama host/port".into());
+    }
+    if c.memory.database_url.is_some() {
+        v.push("memory.database_url set".into());
+    }
+    if c.memory.episodic_path != d.memory.episodic_path {
+        v.push("memory.episodic_path".into());
+    }
+    if !c.mcp.servers.is_empty() {
+        v.push(format!("mcp.servers: {}", c.mcp.servers.len()));
+    }
+    if c.llm.provider != d.llm.provider {
+        v.push("llm.provider".into());
+    }
+    if c.llm.openai_api_base != d.llm.openai_api_base {
+        v.push("llm.openai_api_base".into());
+    }
+    v
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct LlmDoctorJson {
+    pub provider: String,
+    pub model: String,
+    pub openai_api_base: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct OllamaProbeJson {
+    pub url: String,
+    pub ok: bool,
+    pub detail: String,
+}
+
+pub fn list_mcp_servers_public(path: &Path) -> Result<Vec<McpServerPublic>, Box<dyn std::error::Error>> {
+    let mcp = load_mcp_config_from_file(path)?;
+    Ok(
+        mcp.servers
+            .iter()
+            .map(|s| McpServerPublic {
+                name: s.name.clone(),
+                url: s.url.clone(),
+                transport: match s.transport {
+                    McpTransport::Http => "http".to_string(),
+                    McpTransport::Sse => "sse".to_string(),
+                    McpTransport::Stdio => "stdio".to_string(),
+                },
+            })
+            .collect(),
+    )
+}
+
+pub async fn mcp_ping_results(path: &Path) -> Result<Vec<McpPingResult>, Box<dyn std::error::Error>> {
+    let mcp = load_mcp_config_from_file(path)?;
+    let mut out = Vec::with_capacity(mcp.servers.len());
+    for server in &mcp.servers {
+        let transport = match server.transport {
+            McpTransport::Http => "http",
+            McpTransport::Sse => "sse",
+            McpTransport::Stdio => "stdio",
+        };
+        let url_display = if server.url.trim().is_empty() {
+            server.command.join(" ")
+        } else {
+            server.url.clone()
+        };
+        let result: Result<
+            Vec<kowalski_core::mcp::types::McpToolDescription>,
+            kowalski_core::KowalskiError,
+        > = if matches!(server.transport, McpTransport::Stdio) {
+            match kowalski_core::McpStdioClient::connect(server).await {
+                Ok(c) => c.list_tools().await,
+                Err(e) => Err(e),
+            }
+        } else {
+            match kowalski_core::mcp::McpClient::connect_server(server).await {
+                Ok(c) => c.list_tools().await,
+                Err(e) => Err(e),
+            }
+        };
+        match result {
+            Ok(tools) => out.push(McpPingResult {
+                name: server.name.clone(),
+                url: url_display,
+                transport: transport.to_string(),
+                ok: true,
+                tool_count: Some(tools.len()),
+                error: None,
+            }),
+            Err(e) => out.push(McpPingResult {
+                name: server.name.clone(),
+                url: url_display,
+                transport: transport.to_string(),
+                ok: false,
+                tool_count: None,
+                error: Some(e.to_string()),
+            }),
+        }
+    }
+    Ok(out)
+}
+
+async fn probe_ollama_tags(base: &str) -> OllamaProbeJson {
+    let base = base.trim_end_matches('/');
+    let tags_url = format!("{}/api/tags", base);
+    match reqwest::get(&tags_url).await {
+        Ok(r) => {
+            if r.status().is_success() {
+                OllamaProbeJson {
+                    url: tags_url,
+                    ok: true,
+                    detail: format!("HTTP {}", r.status()),
+                }
+            } else {
+                OllamaProbeJson {
+                    url: tags_url,
+                    ok: false,
+                    detail: format!("HTTP {}", r.status()),
+                }
+            }
+        }
+        Err(e) => OllamaProbeJson {
+            url: tags_url,
+            ok: false,
+            detail: e.to_string(),
+        },
+    }
+}
+
+pub async fn doctor_json(ollama_base: Option<String>, config: Option<&Config>) -> DoctorJson {
+    let base = ollama_base.unwrap_or_else(|| "http://127.0.0.1:11434".to_string());
+    let ollama = probe_ollama_tags(&base).await;
+    let c = config.cloned().unwrap_or_default();
+    let llm = LlmDoctorJson {
+        provider: c.llm.provider.clone(),
+        model: c.ollama.model.clone(),
+        openai_api_base: c.llm.openai_api_base.clone(),
+    };
+    let operator = DoctorOperatorJson {
+        mcp_servers_configured: c.mcp.servers.len(),
+        postgres_memory_configured: kowalski_core::config::memory_uses_postgres(&c.memory),
+        config_divergence: config_divergence_lines(&c),
+        mcp_streamable_session_note: "After initialize, Streamable HTTP MCP session ids are available via `McpClient::session_id()` (and `McpClient::shutdown()` clears the session).",
+    };
+    DoctorJson {
+        server_version: env!("CARGO_PKG_VERSION").to_string(),
+        ollama,
+        llm,
+        operator,
+    }
+}

--- a/kowalski/src/main.rs
+++ b/kowalski/src/main.rs
@@ -1,0 +1,67 @@
+use clap::Parser;
+
+#[derive(Parser, Debug)]
+#[clap(
+    author,
+    version,
+    about = "Kowalski server",
+    long_about = "Run the Kowalski HTTP API server used by the UI."
+)]
+struct Cli {
+    #[clap(subcommand)]
+    command: Commands,
+}
+
+#[derive(Parser, Debug)]
+enum Commands {
+    /// Expose a JSON HTTP API for the UI (`GET /api/health`, etc.)
+    Serve {
+        /// Listen address (default 127.0.0.1:3456 — matches `ui/vite.config.ts` proxy)
+        #[clap(long, default_value = "127.0.0.1:3456")]
+        bind: String,
+        /// Config TOML path (default ./config.toml)
+        #[clap(short, long)]
+        config: Option<String>,
+        /// Ollama base URL for `/api/doctor` (default http://127.0.0.1:11434)
+        #[clap(long)]
+        ollama_url: Option<String>,
+        /// TLS certificate (PEM). Must be set together with `--tls-key`.
+        #[clap(long, value_name = "PEM")]
+        tls_cert: Option<std::path::PathBuf>,
+        /// TLS private key (PEM). Must be set together with `--tls-cert`.
+        #[clap(long, value_name = "PEM")]
+        tls_key: Option<std::path::PathBuf>,
+    },
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
+    let cli = Cli::parse();
+
+    match cli.command {
+        Commands::Serve {
+            bind,
+            config,
+            ollama_url,
+            tls_cert,
+            tls_key,
+        } => {
+            let addr: std::net::SocketAddr = bind.parse().map_err(|e| {
+                format!("Invalid --bind {:?}: {}", bind, e)
+            })?;
+            let tls = match (tls_cert, tls_key) {
+                (Some(c), Some(k)) => Some((c, k)),
+                (None, None) => None,
+                _ => {
+                    return Err(
+                        "--tls-cert and --tls-key must be set together (or both omitted)".into(),
+                    );
+                }
+            };
+            kowalski_cli::http_api::serve(addr, config, ollama_url, tls).await?;
+        }
+    }
+
+    Ok(())
+}

--- a/kowalski/src/main.rs
+++ b/kowalski/src/main.rs
@@ -11,30 +11,21 @@ mod http_ops;
     long_about = "Run the Kowalski HTTP API server used by the UI."
 )]
 struct Cli {
-    #[clap(subcommand)]
-    command: Commands,
-}
-
-#[derive(Parser, Debug)]
-enum Commands {
-    /// Expose a JSON HTTP API for the UI (`GET /api/health`, etc.)
-    Serve {
-        /// Listen address (default 127.0.0.1:3456 — matches `ui/vite.config.ts` proxy)
-        #[clap(long, default_value = "127.0.0.1:3456")]
-        bind: String,
-        /// Config TOML path (default ./config.toml)
-        #[clap(short, long)]
-        config: Option<String>,
-        /// Ollama base URL for `/api/doctor` (default http://127.0.0.1:11434)
-        #[clap(long)]
-        ollama_url: Option<String>,
-        /// TLS certificate (PEM). Must be set together with `--tls-key`.
-        #[clap(long, value_name = "PEM")]
-        tls_cert: Option<std::path::PathBuf>,
-        /// TLS private key (PEM). Must be set together with `--tls-cert`.
-        #[clap(long, value_name = "PEM")]
-        tls_key: Option<std::path::PathBuf>,
-    },
+    /// Listen address (default 127.0.0.1:3456 — matches `ui/vite.config.ts` proxy)
+    #[clap(long, default_value = "127.0.0.1:3456")]
+    bind: String,
+    /// Config TOML path (default ./config.toml)
+    #[clap(short, long)]
+    config: Option<String>,
+    /// Ollama base URL for `/api/doctor` (default http://127.0.0.1:11434)
+    #[clap(long)]
+    ollama_url: Option<String>,
+    /// TLS certificate (PEM). Must be set together with `--tls-key`.
+    #[clap(long, value_name = "PEM")]
+    tls_cert: Option<std::path::PathBuf>,
+    /// TLS private key (PEM). Must be set together with `--tls-cert`.
+    #[clap(long, value_name = "PEM")]
+    tls_key: Option<std::path::PathBuf>,
 }
 
 #[tokio::main]
@@ -42,29 +33,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
     let cli = Cli::parse();
 
-    match cli.command {
-        Commands::Serve {
-            bind,
-            config,
-            ollama_url,
-            tls_cert,
-            tls_key,
-        } => {
-            let addr: std::net::SocketAddr = bind.parse().map_err(|e| {
-                format!("Invalid --bind {:?}: {}", bind, e)
-            })?;
-            let tls = match (tls_cert, tls_key) {
-                (Some(c), Some(k)) => Some((c, k)),
-                (None, None) => None,
-                _ => {
-                    return Err(
-                        "--tls-cert and --tls-key must be set together (or both omitted)".into(),
-                    );
-                }
-            };
-            http_api::serve(addr, config, ollama_url, tls).await?;
+    let addr: std::net::SocketAddr = cli.bind.parse().map_err(|e| {
+        format!("Invalid --bind {:?}: {}", cli.bind, e)
+    })?;
+    let tls = match (cli.tls_cert, cli.tls_key) {
+        (Some(c), Some(k)) => Some((c, k)),
+        (None, None) => None,
+        _ => {
+            return Err("--tls-cert and --tls-key must be set together (or both omitted)".into());
         }
-    }
+    };
+    http_api::serve(addr, cli.config, cli.ollama_url, tls).await?;
 
     Ok(())
 }

--- a/kowalski/src/main.rs
+++ b/kowalski/src/main.rs
@@ -1,5 +1,8 @@
 use clap::Parser;
 
+mod http_api;
+mod http_ops;
+
 #[derive(Parser, Debug)]
 #[clap(
     author,
@@ -59,7 +62,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     );
                 }
             };
-            kowalski_cli::http_api::serve(addr, config, ollama_url, tls).await?;
+            http_api::serve(addr, config, ollama_url, tls).await?;
         }
     }
 

--- a/ui/AGENTS.md
+++ b/ui/AGENTS.md
@@ -4,7 +4,7 @@
 
 ## Role
 
-Vue 3 + Vite + TypeScript single-page app. It is **not** the source of truth for business logic: the **`kowalski-cli serve`** API defines behavior. This UI only consumes `/api/*`.
+Vue 3 + Vite + TypeScript single-page app. It is **not** the source of truth for business logic: the **`kowalski`** API defines behavior. This UI only consumes `/api/*`.
 
 ## Conventions
 

--- a/ui/DEPLOY.md
+++ b/ui/DEPLOY.md
@@ -13,7 +13,7 @@ Artifacts land in `dist/`. Serve `dist/` as static files from any CDN or object 
 
 ## API base URL
 
-The dev server proxies `/api` to `kowalski-cli serve` (see `vite.config.ts`). In production, set **`VITE_API_BASE`** to the **origin** of the HTTP API **before** `bun run build`, for example:
+The dev server proxies `/api` to `kowalski` (see `vite.config.ts`). In production, set **`VITE_API_BASE`** to the **origin** of the HTTP API **before** `bun run build`, for example:
 
 ```bash
 VITE_API_BASE=https://kowalski.example.com bun run build
@@ -23,4 +23,4 @@ If the UI and API share the same origin, you can use an empty base or `/` per `a
 
 ## CORS
 
-`serve` uses permissive CORS for local dev. For a locked-down production split (UI on CDN, API on another host), restrict CORS in a reverse proxy or extend the Axum layer as needed.
+`kowalski` uses permissive CORS for local dev. For a locked-down production split (UI on CDN, API on another host), restrict CORS in a reverse proxy or extend the Axum layer as needed.

--- a/ui/README.md
+++ b/ui/README.md
@@ -40,8 +40,8 @@ In one terminal from the repo root:
 cargo run -p kowalski-cli -- serve -c config.toml
 ```
 
-This binds **`127.0.0.1:3000`** and serves JSON under `/api` (`/api/health`, `/api/doctor`, `/api/mcp/servers`, `POST /api/mcp/ping`, **`POST /api/chat`**, **`POST /api/chat/stream`** (body may include **`tools_stream`: true**), **`POST /api/chat/reset`**). With **`kowalski-cli --features postgres`** and a Postgres memory URL, graph routes may include **`POST /api/graph/cypher`** (Apache AGE on the server). Use `-c` / `--ollama-url` as needed (see `kowalski-cli serve --help`).
+This binds **`127.0.0.1:3456`** and serves JSON under `/api` (`/api/health`, `/api/doctor`, `/api/mcp/servers`, `POST /api/mcp/ping`, **`POST /api/chat`**, **`POST /api/chat/stream`** (body may include **`tools_stream`: true**), **`POST /api/chat/reset`**). With **`kowalski-cli --features postgres`** and a Postgres memory URL, graph routes may include **`POST /api/graph/cypher`** (Apache AGE on the server). Use `-c` / `--ollama-url` as needed (see `kowalski-cli serve --help`).
 
 ## API proxy
 
-`vite.config.ts` proxies `/api` to `http://127.0.0.1:3000` so the Vue app can call relative paths like `/api/health`. For a production build on another origin, set `VITE_API_BASE` to the full API origin (no trailing slash).
+`vite.config.ts` proxies `/api` to `http://127.0.0.1:3456` so the Vue app can call relative paths like `/api/health`. For a production build on another origin, set `VITE_API_BASE` to the full API origin (no trailing slash).

--- a/ui/README.md
+++ b/ui/README.md
@@ -1,6 +1,6 @@
 # Kowalski UI (Vue 3 + Vite)
 
-**Version 1.0.0** · Operator-facing web shell for Kowalski, calling **`kowalski-cli serve`** under `/api/*`.
+**Version 1.0.0** · Operator-facing web shell for Kowalski, calling **`kowalski`** under `/api/*`.
 
 Features: health, MCP ping, **Chat** (`POST /api/chat`, SSE **`POST /api/chat/stream`** with optional **Tool-aware stream** / `tools_stream`), federation, graph extension status. See [`ROADMAP.md`](./ROADMAP.md).
 
@@ -32,15 +32,15 @@ bun run build
 
 Static output is written to `dist/` (suitable for any static host or reverse proxy).
 
-## Backend (CLI HTTP API)
+## Backend (HTTP API)
 
 In one terminal from the repo root:
 
 ```bash
-cargo run -p kowalski-cli -- serve -c config.toml
+cargo run -p kowalski -- -c config.toml
 ```
 
-This binds **`127.0.0.1:3456`** and serves JSON under `/api` (`/api/health`, `/api/doctor`, `/api/mcp/servers`, `POST /api/mcp/ping`, **`POST /api/chat`**, **`POST /api/chat/stream`** (body may include **`tools_stream`: true**), **`POST /api/chat/reset`**). With **`kowalski-cli --features postgres`** and a Postgres memory URL, graph routes may include **`POST /api/graph/cypher`** (Apache AGE on the server). Use `-c` / `--ollama-url` as needed (see `kowalski-cli serve --help`).
+This binds **`127.0.0.1:3456`** and serves JSON under `/api` (`/api/health`, `/api/doctor`, `/api/mcp/servers`, `POST /api/mcp/ping`, **`POST /api/chat`**, **`POST /api/chat/stream`** (body may include **`tools_stream`: true**), **`POST /api/chat/reset`**). With **`kowalski --features postgres`** and a Postgres memory URL, graph routes may include **`POST /api/graph/cypher`** (Apache AGE on the server). Use `-c` / `--ollama-url` as needed (see `kowalski --help`).
 
 ## API proxy
 

--- a/ui/ROADMAP.md
+++ b/ui/ROADMAP.md
@@ -8,4 +8,4 @@
 
 ## Done (1.0.0)
 - [x] Tabs: Home, MCP, Chat (including **Tool-aware stream** / `tools_stream`), Federation, Graph status.
-- [x] Vite proxy to local `serve` on port 3000.
+- [x] Vite proxy to local `serve` on port 3456.

--- a/ui/ROADMAP.md
+++ b/ui/ROADMAP.md
@@ -1,6 +1,6 @@
 # Kowalski UI roadmap
 
-**Package version 1.0.0** (`package.json`). Depends on **`kowalski-cli serve`** for `/api/*`.
+**Package version 1.0.0** (`package.json`). Depends on **`kowalski`** for `/api/*`.
 
 ## Near term
 - [ ] Optional env-driven API base already via `VITE_API_BASE`; document production deploy patterns.
@@ -8,4 +8,4 @@
 
 ## Done (1.0.0)
 - [x] Tabs: Home, MCP, Chat (including **Tool-aware stream** / `tools_stream`), Federation, Graph status.
-- [x] Vite proxy to local `serve` on port 3456.
+- [x] Vite proxy to local `kowalski` on port 3456.

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -1,4 +1,4 @@
-/** Base for API calls. In dev, leave empty so Vite proxies `/api` to the CLI (see vite.config.ts). */
+/** Base for API calls. In dev, leave empty so Vite proxies `/api` to `kowalski` (see vite.config.ts). */
 const base = (import.meta.env.VITE_API_BASE as string | undefined) ?? "";
 
 async function json<T>(path: string, init?: RequestInit): Promise<T> {
@@ -28,7 +28,7 @@ export type Health = {
 };
 
 export type Doctor = {
-  cli_version: string;
+  server_version: string;
   ollama: { url: string; ok: boolean; detail: string };
   llm: {
     provider: string;

--- a/ui/src/panels/HomePanel.vue
+++ b/ui/src/panels/HomePanel.vue
@@ -119,7 +119,7 @@ onUnmounted(() => {
   <section class="panel">
     <h2>API status</h2>
     <p class="hint">
-      Run <code>kowalski-cli serve</code> (default <code>127.0.0.1:3000</code>), then
+      Run <code>kowalski-cli serve</code> (default <code>127.0.0.1:3456</code>), then
       <code>bun run dev</code> in <code>ui/</code>.
     </p>
     <p class="row">

--- a/ui/src/panels/HomePanel.vue
+++ b/ui/src/panels/HomePanel.vue
@@ -119,7 +119,7 @@ onUnmounted(() => {
   <section class="panel">
     <h2>API status</h2>
     <p class="hint">
-      Run <code>kowalski-cli serve</code> (default <code>127.0.0.1:3456</code>), then
+      Run <code>kowalski</code> (default <code>127.0.0.1:3456</code>), then
       <code>bun run dev</code> in <code>ui/</code>.
     </p>
     <p class="row">

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
     proxy: {
       // Forward API calls to a future Kowalski HTTP backend (configure when available)
       "/api": {
-        target: "http://127.0.0.1:3000",
+        target: "http://127.0.0.1:3456",
         changeOrigin: true,
       },
     },


### PR DESCRIPTION
Refactored server/CLI responsibilities:
- kowalski is now the main HTTP API server binary.
- kowalski-cli now focuses on CLI/operator workflows (REPL, config/db/doctor/mcp/federation helpers).

Moved HTTP API ownership out of CLI:
- Server API implementation is now in kowalski/src/http_api.rs.
- Server helper logic is now in kowalski/src/http_ops.rs.
- Removed legacy server module from kowalski-cli.

Simplified server command UX:
- Removed serve subcommand from CLI flow.
- kowalski now starts the server directly (with flags like --bind, -c, --ollama-url, TLS options).

Updated defaults and command/docs alignment:
- Default config behavior: use config.toml when -c/--config is not provided.
- Updated docs/comments/UI guidance from old kowalski-cli serve flow to the new kowalski server flow.

Naming polish:
- /api/doctor payload field updated from cli_version to server_version.
- Corresponding UI API typings adjusted.

